### PR TITLE
SSE Endpoint Event for Message Post endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+plugins:
+  - rubocop-rake
+  - rubocop-rspec
+
 AllCops:
   NewCops: enable
   TargetRubyVersion: 3.1
@@ -29,7 +35,19 @@ Layout/LineLength:
   Max: 120
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 35
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
 
 Metrics/BlockLength:
   Exclude:

--- a/examples/test_local_mcp.rb
+++ b/examples/test_local_mcp.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "bundler/setup"

--- a/examples/test_sse_mcp_tool_call.rb
+++ b/examples/test_sse_mcp_tool_call.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "bundler/setup"

--- a/examples/test_sse_mcp_with_gpt.rb
+++ b/examples/test_sse_mcp_with_gpt.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "bundler/setup"

--- a/lib/ruby_llm/mcp/transport/sse.rb
+++ b/lib/ruby_llm/mcp/transport/sse.rb
@@ -40,6 +40,7 @@ module RubyLLM
           start_sse_listener
         end
 
+        # rubocop:disable Metrics/MethodLength
         def request(body, wait_for_response: true)
           # Generate a unique request ID
           @id_mutex.synchronize { @id_counter += 1 }
@@ -88,6 +89,7 @@ module RubyLLM
             raise RubyLLM::MCP::Errors::TimeoutError.new(message: "Request timed out after 30 seconds")
           end
         end
+        # rubocop:enable Metrics/MethodLength
 
         def close
           @running = false

--- a/lib/ruby_llm/mcp/transport/stdio.rb
+++ b/lib/ruby_llm/mcp/transport/stdio.rb
@@ -150,9 +150,7 @@ module RubyLLM
           response = begin
             JSON.parse(line)
           rescue JSON::ParserError => e
-            puts "Error parsing response as JSON: #{e.message}"
-            puts "Raw response: #{line}"
-            return
+            raise "Error parsing response as JSON: #{e.message}\nRaw response: #{line}"
           end
           request_id = response["id"]&.to_s
 

--- a/ruby_llm-mcp.gemspec
+++ b/ruby_llm-mcp.gemspec
@@ -2,6 +2,7 @@
 
 require_relative "lib/ruby_llm/mcp/version"
 
+# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |spec|
   spec.name = "ruby_llm-mcp"
   spec.version = RubyLLM::MCP::VERSION
@@ -29,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
-  spec.metadata["homepage_uri"] = spec.homepage
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -43,3 +43,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ruby_llm", "~> 1.2"
   spec.add_dependency "zeitwerk", "~> 2"
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/ruby_llm/mcp_spec.rb
+++ b/spec/ruby_llm/mcp_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe RubyLLM::MCP do
   it "has a version number" do
-    expect(RubyLLM::MCP::VERSION).not_to be nil
+    expect(RubyLLM::MCP::VERSION).not_to be_nil
   end
 end


### PR DESCRIPTION
Dynamically support the correct message endpoint from the server instead of assume it's a gsub on "/sse" to "/message".

Instead, when opening the SSE connection we get send a message:
`{data: "/to/a_post_endpoint", event: "endpoint" }`

or

`{data: "https://mymcp.ai/to/a_post_endpoint", event: "endpoint" }`

We will support both full url's and path urls to be sent via the endpoint event.

Thank you to [schappim](https://github.com/schappim) for raising this issue!