### PR TITLE
Coordinator refactor

### DIFF
--- a/lib/ruby_llm/mcp/coordinator.rb
+++ b/lib/ruby_llm/mcp/coordinator.rb
@@ -14,9 +14,9 @@ module RubyLLM
         @transport_type = transport_type
         @config = config
 
-        @request_timeout = config[:request_timeout] || 8000
         @protocol_version = PROTOCOL_VERSION
         @headers = config[:headers] || {}
+
         @transport = nil
         @capabilities = nil
       end
@@ -28,21 +28,26 @@ module RubyLLM
       def start_transport
         case @transport_type
         when :sse
-          @transport = RubyLLM::MCP::Transport::SSE.new(@config[:url], request_timeout: @request_timeout,
-                                                                       headers: @headers)
+          @transport = RubyLLM::MCP::Transport::SSE.new(@config[:url],
+                                                        request_timeout: @config[:request_timeout],
+                                                        headers: @headers)
         when :stdio
-          @transport = RubyLLM::MCP::Transport::Stdio.new(@config[:command], request_timeout: @request_timeout,
-                                                                             args: @config[:args], env: @config[:env])
+          @transport = RubyLLM::MCP::Transport::Stdio.new(@config[:command],
+                                                          request_timeout: @config[:request_timeout],
+                                                          args: @config[:args],
+                                                          env: @config[:env])
         when :streamable
-          @transport = RubyLLM::MCP::Transport::Streamable.new(@config[:url], request_timeout: @request_timeout,
-                                                                              headers: @headers)
+          @transport = RubyLLM::MCP::Transport::Streamable.new(@config[:url],
+                                                               request_timeout: @config[:request_timeout],
+                                                               headers: @headers)
         else
-          raise "Invalid transport type: #{transport_type}"
+          message = "Invalid transport type: :#{transport_type}. Supported types are :sse, :stdio, :streamable"
+          raise Errors::InvalidTransportType.new(message: message)
         end
 
         @initialize_response = initialize_request
         @capabilities = RubyLLM::MCP::Capabilities.new(@initialize_response["result"]["capabilities"])
-        notification_request
+        initialize_notification
       end
 
       def stop_transport
@@ -63,7 +68,7 @@ module RubyLLM
         RubyLLM::MCP::Requests::ToolCall.new(self, **args).call
       end
 
-      def resource_read_request(**args)
+      def resource_read(**args)
         RubyLLM::MCP::Requests::ResourceRead.new(self, **args).call
       end
 
@@ -83,23 +88,23 @@ module RubyLLM
         RubyLLM::MCP::Requests::Initialization.new(self).call
       end
 
-      def notification_request
-        RubyLLM::MCP::Requests::Notification.new(self).call
+      def initialize_notification
+        RubyLLM::MCP::Requests::InitializeNotification.new(self).call
       end
 
-      def tool_list_request
+      def tool_list
         RubyLLM::MCP::Requests::ToolList.new(self).call
       end
 
-      def resources_list_request
+      def resource_list
         RubyLLM::MCP::Requests::ResourceList.new(self).call
       end
 
-      def resource_template_list_request
+      def resource_template_list
         RubyLLM::MCP::Requests::ResourceTemplateList.new(self).call
       end
 
-      def prompt_list_request
+      def prompt_list
         RubyLLM::MCP::Requests::PromptList.new(self).call
       end
     end

--- a/lib/ruby_llm/mcp/coordinator.rb
+++ b/lib/ruby_llm/mcp/coordinator.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module MCP
+    class Coordinator
+      PROTOCOL_VERSION = "2025-03-26"
+      PV_2024_11_05 = "2024-11-05"
+
+      attr_reader :client, :transport_type, :config, :request_timeout, :headers, :transport, :initialize_response,
+                  :capabilities, :protocol_version
+
+      def initialize(client, transport_type:, config: {})
+        @client = client
+        @transport_type = transport_type
+        @config = config
+
+        @request_timeout = config[:request_timeout] || 8000
+        @protocol_version = PROTOCOL_VERSION
+        @headers = config[:headers] || {}
+        @transport = nil
+        @capabilities = nil
+      end
+
+      def request(body, **options)
+        @transport.request(body, **options)
+      end
+
+      def start_transport
+        case @transport_type
+        when :sse
+          @transport = RubyLLM::MCP::Transport::SSE.new(@config[:url], request_timeout: @request_timeout,
+                                                                       headers: @headers)
+        when :stdio
+          @transport = RubyLLM::MCP::Transport::Stdio.new(@config[:command], request_timeout: @request_timeout,
+                                                                             args: @config[:args], env: @config[:env])
+        when :streamable
+          @transport = RubyLLM::MCP::Transport::Streamable.new(@config[:url], request_timeout: @request_timeout,
+                                                                              headers: @headers)
+        else
+          raise "Invalid transport type: #{transport_type}"
+        end
+
+        @initialize_response = initialize_request
+        @capabilities = RubyLLM::MCP::Capabilities.new(@initialize_response["result"]["capabilities"])
+        notification_request
+      end
+
+      def stop_transport
+        @transport&.close
+        @transport = nil
+      end
+
+      def restart_transport
+        stop_transport
+        start_transport
+      end
+
+      def alive?
+        !!@transport&.alive?
+      end
+
+      def execute_tool(**args)
+        RubyLLM::MCP::Requests::ToolCall.new(self, **args).call
+      end
+
+      def resource_read_request(**args)
+        RubyLLM::MCP::Requests::ResourceRead.new(self, **args).call
+      end
+
+      def completion_resource(**args)
+        RubyLLM::MCP::Requests::CompletionResource.new(self, **args).call
+      end
+
+      def completion_prompt(**args)
+        RubyLLM::MCP::Requests::CompletionPrompt.new(self, **args).call
+      end
+
+      def execute_prompt(**args)
+        RubyLLM::MCP::Requests::PromptCall.new(self, **args).call
+      end
+
+      def initialize_request
+        RubyLLM::MCP::Requests::Initialization.new(self).call
+      end
+
+      def notification_request
+        RubyLLM::MCP::Requests::Notification.new(self).call
+      end
+
+      def tool_list_request
+        RubyLLM::MCP::Requests::ToolList.new(self).call
+      end
+
+      def resources_list_request
+        RubyLLM::MCP::Requests::ResourceList.new(self).call
+      end
+
+      def resource_template_list_request
+        RubyLLM::MCP::Requests::ResourceTemplateList.new(self).call
+      end
+
+      def prompt_list_request
+        RubyLLM::MCP::Requests::PromptList.new(self).call
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/mcp/errors.rb
+++ b/lib/ruby_llm/mcp/errors.rb
@@ -12,15 +12,17 @@ module RubyLLM
         end
       end
 
+      class CompletionNotAvailable < BaseError; end
+
+      class PromptArgumentError < BaseError; end
+
       class InvalidProtocolVersionError < BaseError; end
 
       class SessionExpiredError < BaseError; end
 
       class TimeoutError < BaseError; end
 
-      class PromptArgumentError < BaseError; end
-
-      class CompletionNotAvailable < BaseError; end
+      class InvalidTransportType < BaseError; end
     end
   end
 end

--- a/lib/ruby_llm/mcp/requests/initialize_notification.rb
+++ b/lib/ruby_llm/mcp/requests/initialize_notification.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RubyLLM::MCP::Requests::Notification < RubyLLM::MCP::Requests::Base
+class RubyLLM::MCP::Requests::InitializeNotification < RubyLLM::MCP::Requests::Base
   def call
     client.request(notification_body, add_id: false, wait_for_response: false)
   end

--- a/lib/ruby_llm/mcp/resource.rb
+++ b/lib/ruby_llm/mcp/resource.rb
@@ -3,10 +3,10 @@
 module RubyLLM
   module MCP
     class Resource
-      attr_reader :uri, :name, :description, :mime_type, :mcp_client
+      attr_reader :uri, :name, :description, :mime_type, :coordinator
 
-      def initialize(mcp_client, resource)
-        @mcp_client = mcp_client
+      def initialize(coordinator, resource)
+        @coordinator = coordinator
         @uri = resource["uri"]
         @name = resource["name"]
         @description = resource["description"]
@@ -64,7 +64,7 @@ module RubyLLM
         when "http", "https"
           fetch_uri_content(uri)
         else # file:// or git://
-          @read_response ||= @mcp_client.resource_read_request(uri: uri)
+          @read_response ||= @coordinator.resource_read_request(uri: uri)
         end
       end
 

--- a/lib/ruby_llm/mcp/resource.rb
+++ b/lib/ruby_llm/mcp/resource.rb
@@ -64,7 +64,7 @@ module RubyLLM
         when "http", "https"
           fetch_uri_content(uri)
         else # file:// or git://
-          @read_response ||= @coordinator.resource_read_request(uri: uri)
+          @read_response ||= @coordinator.resource_read(uri: uri)
         end
       end
 

--- a/lib/ruby_llm/mcp/resource_template.rb
+++ b/lib/ruby_llm/mcp/resource_template.rb
@@ -58,7 +58,7 @@ module RubyLLM
         when "http", "https"
           fetch_uri_content(uri)
         else # file:// or git://
-          @coordinator.resource_read_request(uri: uri)
+          @coordinator.resource_read(uri: uri)
         end
       end
 

--- a/lib/ruby_llm/mcp/resource_template.rb
+++ b/lib/ruby_llm/mcp/resource_template.rb
@@ -3,10 +3,10 @@
 module RubyLLM
   module MCP
     class ResourceTemplate
-      attr_reader :uri, :name, :description, :mime_type, :mcp_client, :template
+      attr_reader :uri, :name, :description, :mime_type, :coordinator, :template
 
-      def initialize(mcp_client, resource)
-        @mcp_client = mcp_client
+      def initialize(coordinator, resource)
+        @coordinator = coordinator
         @uri = resource["uriTemplate"]
         @name = resource["name"]
         @description = resource["description"]
@@ -18,7 +18,7 @@ module RubyLLM
         response = read_response(uri)
         content_response = response.dig("result", "contents", 0)
 
-        Resource.new(mcp_client, {
+        Resource.new(coordinator, {
                        "uri" => uri,
                        "name" => "#{@name} (#{uri})",
                        "description" => @description,
@@ -32,8 +32,8 @@ module RubyLLM
       end
 
       def complete(argument, value)
-        if @mcp_client.capabilities.completion?
-          response = @mcp_client.completion_resource(uri: @uri, argument: argument, value: value)
+        if @coordinator.capabilities.completion?
+          response = @coordinator.completion_resource(uri: @uri, argument: argument, value: value)
           response = response.dig("result", "completion")
 
           Completion.new(values: response["values"], total: response["total"], has_more: response["hasMore"])
@@ -58,7 +58,7 @@ module RubyLLM
         when "http", "https"
           fetch_uri_content(uri)
         else # file:// or git://
-          @mcp_client.resource_read_request(uri: uri)
+          @coordinator.resource_read_request(uri: uri)
         end
       end
 

--- a/lib/ruby_llm/mcp/tool.rb
+++ b/lib/ruby_llm/mcp/tool.rb
@@ -3,11 +3,11 @@
 module RubyLLM
   module MCP
     class Tool < RubyLLM::Tool
-      attr_reader :name, :description, :parameters, :mcp_client, :tool_response
+      attr_reader :name, :description, :parameters, :coordinator, :tool_response
 
-      def initialize(mcp_client, tool_response)
+      def initialize(coordinator, tool_response)
         super()
-        @mcp_client = mcp_client
+        @coordinator = coordinator
 
         @name = tool_response["name"]
         @description = tool_response["description"].to_s
@@ -15,7 +15,7 @@ module RubyLLM
       end
 
       def execute(**params)
-        response = @mcp_client.execute_tool(
+        response = @coordinator.execute_tool(
           name: @name,
           parameters: params
         )
@@ -106,7 +106,7 @@ module RubyLLM
             "content" => content["resource"]
           }
 
-          resource = Resource.new(mcp_client, resource_data)
+          resource = Resource.new(coordinator, resource_data)
           resource.to_content
         end
       end

--- a/spec/ruby_llm/mcp/resource_spec.rb
+++ b/spec/ruby_llm/mcp/resource_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe RubyLLM::MCP::Resource do
 
           expect(resource.name).to eq("test.txt")
           expect(resource.uri).to eq("file://test.txt/")
-          expect(resource.mcp_client).to eq(client)
         end
       end
 


### PR DESCRIPTION
Motivation for this change is to reducing the public interface of our client. Previously, we passed the client instance to downstream classes to enable communication with the MCP server. We're now moving MCP communication into a dedicated coordinator class, which allows us to encapsulate that logic and significantly reduce the client’s public surface area.