### PR TITLE
Fixed enum setting bug and added default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/scripts/
 
 # rspec failure tracking
 .rspec_status

--- a/lib/ruby_llm/mcp/parameter.rb
+++ b/lib/ruby_llm/mcp/parameter.rb
@@ -3,12 +3,13 @@
 module RubyLLM
   module MCP
     class Parameter < RubyLLM::Parameter
-      attr_accessor :items, :properties, :enum, :union_type
+      attr_accessor :items, :properties, :enum, :union_type, :default
 
-      def initialize(name, type: "string", desc: nil, required: true, union_type: nil)
+      def initialize(name, type: "string", desc: nil, required: true, default: nil, union_type: nil) # rubocop:disable Metrics/ParameterLists
         super(name, type: type.to_sym, desc: desc, required: required)
         @properties = {}
         @union_type = union_type
+        @default = default
       end
 
       def item_type

--- a/lib/ruby_llm/mcp/providers/anthropic/complex_parameter_support.rb
+++ b/lib/ruby_llm/mcp/providers/anthropic/complex_parameter_support.rb
@@ -28,8 +28,9 @@ module RubyLLM
               else
                 {
                   type: param.type,
+                  default: param.default,
                   items: { type: param.item_type, enum: param.enum }.compact
-                }
+                }.compact
               end
             when :object
               {

--- a/lib/ruby_llm/mcp/providers/gemini/complex_parameter_support.rb
+++ b/lib/ruby_llm/mcp/providers/gemini/complex_parameter_support.rb
@@ -30,8 +30,9 @@ module RubyLLM
                            else
                              {
                                type: param_type_for_gemini(param.type),
+                               default: param.default,
                                items: { type: param_type_for_gemini(param.item_type), enum: param.enum }.compact
-                             }
+                             }.compact
                            end
                          when :object
                            {

--- a/lib/ruby_llm/mcp/providers/openai/complex_parameter_support.rb
+++ b/lib/ruby_llm/mcp/providers/openai/complex_parameter_support.rb
@@ -21,8 +21,9 @@ module RubyLLM
                            else
                              {
                                type: param.type,
+                               default: param.default,
                                items: { type: param.item_type, enum: param.enum }.compact
-                             }
+                             }.compact
                            end
                          when :object
                            {

--- a/lib/ruby_llm/mcp/tool.rb
+++ b/lib/ruby_llm/mcp/tool.rb
@@ -70,7 +70,8 @@ module RubyLLM
           key,
           type: param_data["type"] || lifted_type,
           desc: param_data["description"],
-          required: param_data["required"]
+          required: param_data["required"],
+          default: param_data["default"]
         )
 
         if param.type == :array
@@ -79,8 +80,8 @@ module RubyLLM
           if items.key?("properties")
             param.properties = create_parameters(items)
           end
-          if param_data.key?("enum")
-            param.enum = param_data["enum"]
+          if items.key?("enum")
+            param.enum = items["enum"]
           end
         elsif param.type == :object
           if param_data.key?("properties")


### PR DESCRIPTION
This PR aims to solve the issues found from https://github.com/patvice/ruby_llm-mcp/issues/21

Includes
- We will now set the enum options on array correctly
- We will include a default field if it's provided by the MCP