### PR TITLE
Changing Zeitwerk setup

### DIFF
--- a/lib/ruby_llm/chat.rb
+++ b/lib/ruby_llm/chat.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# This is an override of the RubyLLM::Chat class to convient methods for easy MCP support
+# This is an override of the RubyLLM::Chat class to add convenient methods to more
+# easily work with the MCP clients.
 module RubyLLM
   class Chat
     def with_resources(*resources, **args)

--- a/lib/ruby_llm/mcp.rb
+++ b/lib/ruby_llm/mcp.rb
@@ -42,4 +42,3 @@ loader.inflector.inflect("openai" => "OpenAI")
 loader.inflector.inflect("streamable_http" => "StreamableHTTP")
 
 loader.setup
-loader.eager_load

--- a/ruby_llm-mcp.gemspec
+++ b/ruby_llm-mcp.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.glob("lib/**/*") + ["README.md", "LICENSE"]
+  spec.files = Dir.glob("lib/ruby_llm/**/*") + ["README.md", "LICENSE"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "httpx", "~> 1.4"


### PR DESCRIPTION
This is a followup PR to address the issue with loading the gem with Zeitwerk related in issue https://github.com/patvice/ruby_llm-mcp/issues/29. 

Running Zeitwerk under the definition of `RubyLLM::MCP` will ensure that this class definition will be defined before Zeitwerk was loaded.