### PR TITLE
Fix nil handling in item_type method and add parameter specs

### DIFF
--- a/lib/ruby_llm/mcp/parameter.rb
+++ b/lib/ruby_llm/mcp/parameter.rb
@@ -15,7 +15,7 @@ module RubyLLM
       end
 
       def item_type
-        @items["type"].to_sym
+        @items&.[]("type")&.to_sym
       end
     end
   end

--- a/lib/ruby_llm/mcp/parameter.rb
+++ b/lib/ruby_llm/mcp/parameter.rb
@@ -15,7 +15,7 @@ module RubyLLM
       end
 
       def item_type
-        @items&.[]("type")&.to_sym
+        @items&.dig("type")&.to_sym
       end
     end
   end

--- a/spec/ruby_llm/mcp/parameter_spec.rb
+++ b/spec/ruby_llm/mcp/parameter_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyLLM::MCP::Parameter do
+  describe "#item_type" do
+    context "when @items is nil" do
+      it "returns nil" do
+        parameter = described_class.new("test_param", type: "string")
+        expect(parameter.item_type).to be_nil
+      end
+    end
+
+    context "when @items is empty hash" do
+      it "returns nil" do
+        parameter = described_class.new("test_param", type: "string")
+        parameter.items = {}
+        expect(parameter.item_type).to be_nil
+      end
+    end
+
+    context "when @items['type'] is nil" do
+      it "returns nil" do
+        parameter = described_class.new("test_param", type: "string")
+        parameter.items = { "other_key" => "value" }
+        expect(parameter.item_type).to be_nil
+      end
+    end
+
+    context "when @items['type'] has a value" do
+      it "returns the type as a symbol" do
+        parameter = described_class.new("test_param", type: "array")
+        parameter.items = { "type" => "string" }
+        expect(parameter.item_type).to eq(:string)
+      end
+    end
+  end
+
+  describe "#initialize" do
+    it "creates a parameter with default values" do
+      parameter = described_class.new("test_param")
+      expect(parameter.name).to eq("test_param")
+      expect(parameter.type).to eq(:string)
+      expect(parameter.required).to be(true)
+      expect(parameter.items).to be_nil
+    end
+
+    it "creates a parameter with custom values" do
+      parameter = described_class.new("test_param", type: "array", desc: "Test description", required: false)
+      expect(parameter.name).to eq("test_param")
+      expect(parameter.type).to eq(:array)
+      expect(parameter.desc).to eq("Test description")
+      expect(parameter.required).to be(false)
+    end
+  end
+end

--- a/spec/ruby_llm/mcp/parameter_spec.rb
+++ b/spec/ruby_llm/mcp/parameter_spec.rb
@@ -2,35 +2,32 @@
 
 RSpec.describe RubyLLM::MCP::Parameter do
   describe "#item_type" do
-    context "when @items is nil" do
-      it "returns nil" do
-        parameter = described_class.new("test_param", type: "string")
-        expect(parameter.item_type).to be_nil
-      end
+    it "when @items is nil will return nil" do
+      parameter = described_class.new("test_param", type: "string")
+      expect(parameter.item_type).to be_nil
     end
 
-    context "when @items is empty hash" do
-      it "returns nil" do
-        parameter = described_class.new("test_param", type: "string")
-        parameter.items = {}
-        expect(parameter.item_type).to be_nil
-      end
+    it "when @items is empty hash it will returns nil" do
+      parameter = described_class.new("test_param", type: "string")
+      parameter.items = {}
+      expect(parameter.item_type).to be_nil
     end
 
-    context "when @items['type'] is nil" do
-      it "returns nil" do
-        parameter = described_class.new("test_param", type: "string")
-        parameter.items = { "other_key" => "value" }
-        expect(parameter.item_type).to be_nil
-      end
+    it "when @items['type'] is nil it will return nil" do
+      parameter = described_class.new("test_param", type: "string")
+      parameter.items = { "other_key" => "value" }
+      expect(parameter.item_type).to be_nil
     end
 
-    context "when @items['type'] has a value" do
-      it "returns the type as a symbol" do
-        parameter = described_class.new("test_param", type: "array")
-        parameter.items = { "type" => "string" }
-        expect(parameter.item_type).to eq(:string)
-      end
+    it "when type is an array and item is not defined it will return nill" do
+      parameter = described_class.new("test_param", type: "array")
+      expect(parameter.item_type).to be_nil
+    end
+
+    it "when @items['type'] has a value it will returns the type as a symbol" do
+      parameter = described_class.new("test_param", type: "array")
+      parameter.items = { "type" => "string" }
+      expect(parameter.item_type).to eq(:string)
     end
   end
 
@@ -47,7 +44,7 @@ RSpec.describe RubyLLM::MCP::Parameter do
       parameter = described_class.new("test_param", type: "array", desc: "Test description", required: false)
       expect(parameter.name).to eq("test_param")
       expect(parameter.type).to eq(:array)
-      expect(parameter.desc).to eq("Test description")
+      expect(parameter.description).to eq("Test description")
       expect(parameter.required).to be(false)
     end
   end


### PR DESCRIPTION
This commit updates the `item_type` method to safely handle cases where the `@items` variable may be nil, preventing potential exceptions. The change utilizes the safe navigation operator `&.` to ensure the method returns nil instead of raising an error when `@items` is not properly initialized.

Additionally, this commit introduces a set of RSpec tests for the `RubyLLM::MCP::Parameter` class. These tests cover various cases for the `item_type` method, ensuring it behaves correctly regarding the presence or absence of the `type` key in the `@items` hash as well as validating the class initialization. This enhancement improves code robustness and test coverage.

In Model Context Protocol (MCP), having a nil value for the item type in a Parameter object has specific implications:

MCP Parameter Schema Context

In MCP, parameters are defined using JSON Schema, and the items property is used specifically for array-type parameters to define the schema of array elements.

What nil item_type means:

1. Non-array parameter - If @items["type"] is nil, it most likely means this parameter is not an array type. The items property is only relevant for parameters with "type": "array".
2. Missing or incomplete schema - It could indicate:
- The parameter schema doesn't include an items definition
- The parameter is a primitive type (string, number, boolean, etc.) rather than an array
- The schema is malformed or incomplete
3. Expected behavior - For non-array parameters, item_type returning nil is actually correct behavior since there's no array element type to describe.

Example MCP Parameter Schemas:

```json
// Array parameter (would have item_type)
{
"type": "array",
  "items": {
    "type": "string"  // This would make item_type return :string
  }
}

// Non-array parameter (item_type should be nil)
{
  "type": "string"  // No "items" property, so item_type is nil
}
```

The nil guard is correct because:

- It prevents crashes when checking item_type on non-array parameters
- It follows the MCP specification where items is only meaningful for array types
- It allows the code to gracefully handle both array and non-array parameters

The nil guard makes your Parameter class more robust when dealing with the variety of parameter types that MCP supports.