### PR TITLE
Improved MCP Connection Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,23 @@ end
 
 You can also avoid this completely manually start and stop the clients if you so choose.
 
+If you want to use the clients outside of the block, you can use the `clients` method to get the clients.
+
+```ruby
+clients = RubyLLM::MCP.establish_connection
+chat = RubyLLM.chat(model: "gpt-4")
+chat.with_tools(*clients.tools)
+
+response = chat.ask("Hello, world!")
+puts response
+```
+
+However, you will be responsible for closing the connection when you are done with it.
+
+```ruby
+RubyLLM::MCP.close_connection
+```
+
 ## Client Lifecycle Management
 
 You can manage the MCP client connection lifecycle:

--- a/lib/ruby_llm/mcp.rb
+++ b/lib/ruby_llm/mcp.rb
@@ -33,8 +33,18 @@ module RubyLLM
 
     def establish_connection(&)
       clients.each(&:start)
-      yield clients
-    ensure
+      if block_given?
+        begin
+          yield clients
+        ensure
+          close_connection
+        end
+      else
+        clients
+      end
+    end
+
+    def close_connection
       clients.each do |client|
         client.stop if client.alive?
       end


### PR DESCRIPTION
`RubyLLM::MCP#establish_connection` will now take a block optionally. If the block is not provided, we will start all clients. If a block is provided, we will start all clients, yield the clients to the block and then close all clients.

We are going to add a new method to `RubyLLM::MCP#close_connection` in case you called `RubyLLM::MCP#establish_connection` without a block.


From feedback from @MadBomber - https://github.com/patvice/ruby_llm-mcp/issues/40. Thanks so much!