### PR TITLE
Support MCP#Clients Accessor

### DIFF
--- a/lib/ruby_llm/mcp.rb
+++ b/lib/ruby_llm/mcp.rb
@@ -8,12 +8,18 @@ module RubyLLM
   module MCP
     module_function
 
-    def clients(config = RubyLLM::MCP.config.mcp_configuration)
+    def clients
+      @clients ||= build_clients unless @built_clients
+      @clients
+    end
+
+    def build_clients(config = RubyLLM::MCP.config.mcp_configuration)
       @clients ||= {}
-      config.map do |options|
+      clients = config.map do |options|
         @clients[options[:name]] ||= Client.new(**options)
       end
-      @clients
+      @built_clients = true
+      clients
     end
 
     def add_client(options)

--- a/lib/ruby_llm/mcp.rb
+++ b/lib/ruby_llm/mcp.rb
@@ -8,28 +8,22 @@ module RubyLLM
   module MCP
     module_function
 
-    def clients
-      @clients ||= build_clients unless @built_clients
+    def clients(config = RubyLLM::MCP.config.mcp_configuration)
+      if @clients.nil?
+        @clients = {}
+        config.map do |options|
+          @clients[options[:name]] ||= Client.new(**options)
+        end
+      end
       @clients
     end
 
-    def build_clients(config = RubyLLM::MCP.config.mcp_configuration)
-      @clients ||= {}
-      clients = config.map do |options|
-        @clients[options[:name]] ||= Client.new(**options)
-      end
-      @built_clients = true
-      clients
-    end
-
     def add_client(options)
-      @clients ||= {}
-      @clients[options[:name]] ||= Client.new(**options)
+      clients[options[:name]] ||= Client.new(**options)
     end
 
     def remove_client(name)
-      @clients ||= {}
-      client = @clients.delete(name)
+      client = clients.delete(name)
       client&.stop
       client
     end

--- a/lib/ruby_llm/mcp.rb
+++ b/lib/ruby_llm/mcp.rb
@@ -13,6 +13,7 @@ module RubyLLM
       config.map do |options|
         @clients[options[:name]] ||= Client.new(**options)
       end
+      @clients
     end
 
     def add_client(options)

--- a/spec/ruby_llm/mcp_spec.rb
+++ b/spec/ruby_llm/mcp_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe RubyLLM::MCP do
     it "creates clients from config" do
       clients = RubyLLM::MCP.clients
 
-      expect(clients).to eq([client_stdio, client_sse])
+      expect(clients).to eq({ "client1" => client_stdio, "client2" => client_sse })
     end
 
     it "caches clients" do
@@ -62,7 +62,19 @@ RSpec.describe RubyLLM::MCP do
 
       clients = RubyLLM::MCP.clients(custom_config)
 
-      expect(clients).to eq([custom_client])
+      expect(clients.keys).to eq(%w[custom])
+      expect(clients["custom"]).to eq(custom_client)
+    end
+
+    it "if a client is added, it will also return from the clients hash" do
+      custom_client = instance_double(RubyLLM::MCP::Client)
+      allow(RubyLLM::MCP::Client).to receive(:new).with(name: "custom",
+                                                        transport_type: "stdio").and_return(custom_client)
+      RubyLLM::MCP.add_client(name: "custom", transport_type: "stdio")
+
+      clients = RubyLLM::MCP.clients
+
+      expect(clients["custom"]).to eq(custom_client)
     end
   end
 


### PR DESCRIPTION
This is a change to allow MCP#Clients to return a hash instead of an array. It will also return the all clients currently registered/managed by MCP module. 

The idea came from https://github.com/patvice/ruby_llm-mcp/issues/48, with a goal of support more access to @clients, allowing for easier access to all defined MCPs.