### PR TITLE
Force http/1.1 to get better SSE support

### DIFF
--- a/lib/ruby_llm/mcp/transports/sse.rb
+++ b/lib/ruby_llm/mcp/transports/sse.rb
@@ -165,6 +165,7 @@ module RubyLLM
         def stream_events_from_server
           sse_client = HTTPX.plugin(:stream)
           sse_client = sse_client.with(
+            ssl: { alpn_protocols: ["http/1.1"] },
             headers: @headers
           )
           response = sse_client.get(@event_url, stream: true)

--- a/lib/ruby_llm/mcp/transports/streamable_http.rb
+++ b/lib/ruby_llm/mcp/transports/streamable_http.rb
@@ -422,8 +422,8 @@ module RubyLLM
             end
 
             # Set up SSE streaming connection with callbacks
-            connection = create_connection_with_sse_callbacks(options)
-            response = connection.get(@url, headers: headers)
+            connection = create_connection_with_sse_callbacks(options, headers)
+            response = connection.get(@url)
 
             # Handle HTTPX error responses first
             error_result = handle_httpx_error_response!(response, context: { location: "SSE connection" },
@@ -463,7 +463,7 @@ module RubyLLM
           end
         end
 
-        def create_connection_with_sse_callbacks(options)
+        def create_connection_with_sse_callbacks(options, headers)
           buffer = +""
 
           client = HTTPX
@@ -501,7 +501,9 @@ module RubyLLM
                 read_timeout: @request_timeout / 1000,
                 write_timeout: @request_timeout / 1000,
                 operation_timeout: @request_timeout / 1000
-              }
+              },
+              headers: headers,
+              ssl: { alpn_protocols: ["http/1.1"] }
             )
           register_client(client)
         end


### PR DESCRIPTION
Released to https://github.com/patvice/ruby_llm-mcp/issues/52

There is a hunch that http2 is causing failures in some environments or inconstancy in others. This forces HTTPX to use http1.1 when setting up a connection for SSE streams and when we get back a text/event_stream response from StreamableHTTP protocol.