### PR TITLE
Establish Connection V0.6 Fix

### DIFF
--- a/lib/ruby_llm/mcp.rb
+++ b/lib/ruby_llm/mcp.rb
@@ -34,7 +34,7 @@ module RubyLLM
     end
 
     def establish_connection(&)
-      clients.each(&:start)
+      clients.each_value(&:start)
       if block_given?
         begin
           yield clients
@@ -47,7 +47,7 @@ module RubyLLM
     end
 
     def close_connection
-      clients.each do |client|
+      clients.each_value do |client|
         client.stop if client.alive?
       end
     end

--- a/lib/ruby_llm/mcp/version.rb
+++ b/lib/ruby_llm/mcp/version.rb
@@ -2,6 +2,6 @@
 
 module RubyLLM
   module MCP
-    VERSION = "0.6.0"
+    VERSION = "0.6.1"
   end
 end

--- a/ruby_llm-mcp.gemspec
+++ b/ruby_llm-mcp.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     services. Makes using MCP with RubyLLM as easy as possible.
   DESC
 
-  spec.homepage = "https://github.com/patvice/ruby_llm-mcp"
+  spec.homepage = "https://www.rubyllm-mcp.com"
   spec.license = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 3.1.3")
 
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httpx", "~> 1.4"
   spec.add_dependency "json-schema", "~> 5.0"
   spec.add_dependency "ruby_llm", "~> 1.3"
+  spec.add_dependency "thor", "~> 1.3"
   spec.add_dependency "zeitwerk", "~> 2"
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/ruby_llm/mcp_spec.rb
+++ b/spec/ruby_llm/mcp_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe RubyLLM::MCP do
   describe "#establish_connection" do
     let(:client_streamable_http) { instance_double(RubyLLM::MCP::Client) }
     let(:client_stdio) { instance_double(RubyLLM::MCP::Client) }
-    let(:clients) { [client_streamable_http, client_stdio] }
+    let(:clients) { { "streamable_http" => client_streamable_http, "stdio" => client_stdio } }
 
     before do
       allow(RubyLLM::MCP).to receive(:clients).and_return(clients)
@@ -189,7 +189,7 @@ RSpec.describe RubyLLM::MCP do
   describe "#close_connection" do
     let(:alive_client) { instance_double(RubyLLM::MCP::Client) }
     let(:dead_client) { instance_double(RubyLLM::MCP::Client) }
-    let(:clients) { [alive_client, dead_client] }
+    let(:clients) { { "alive_client" => alive_client, "dead_client" => dead_client } }
 
     before do
       allow(RubyLLM::MCP).to receive(:clients).and_return(clients)


### PR DESCRIPTION
Fixes https://github.com/patvice/ruby_llm-mcp/issues/59. 

Clients was updated to a hash value to be able to more easily pull estimated clients, rather then an array. However establish_connection was not updated properly.