### PR TITLE
Convert parameter types from symbols to strings

### DIFF
--- a/lib/ruby_llm/mcp/parameter.rb
+++ b/lib/ruby_llm/mcp/parameter.rb
@@ -8,14 +8,14 @@ module RubyLLM
       attr_accessor :items, :properties, :enum, :union_type, :default
 
       def initialize(name, type: "string", desc: nil, required: true, default: nil, union_type: nil) # rubocop:disable Metrics/ParameterLists
-        super(name, type: type.to_sym, desc: desc, required: required)
+        super(name, type: type, desc: desc, required: required)
         @properties = {}
         @union_type = union_type
         @default = default
       end
 
       def item_type
-        @items&.dig("type")&.to_sym
+        @items&.dig("type")
       end
 
       def as_json(*_args)

--- a/spec/ruby_llm/mcp/parameter_spec.rb
+++ b/spec/ruby_llm/mcp/parameter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RubyLLM::MCP::Parameter do
     it "when @items['type'] has a value it will returns the type as a symbol" do
       parameter = described_class.new("test_param", type: "array")
       parameter.items = { "type" => "string" }
-      expect(parameter.item_type).to eq(:string)
+      expect(parameter.item_type).to eq("string")
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe RubyLLM::MCP::Parameter do
     it "creates a parameter with default values" do
       parameter = described_class.new("test_param")
       expect(parameter.name).to eq("test_param")
-      expect(parameter.type).to eq(:string)
+      expect(parameter.type).to eq("string")
       expect(parameter.required).to be(true)
       expect(parameter.items).to be_nil
     end
@@ -43,7 +43,7 @@ RSpec.describe RubyLLM::MCP::Parameter do
     it "creates a parameter with custom values" do
       parameter = described_class.new("test_param", type: "array", desc: "Test description", required: false)
       expect(parameter.name).to eq("test_param")
-      expect(parameter.type).to eq(:array)
+      expect(parameter.type).to eq("array")
       expect(parameter.description).to eq("Test description")
       expect(parameter.required).to be(false)
     end


### PR DESCRIPTION
# Convert Parameter Types from Symbols to Strings

# Problem
A MCP parameter type can be an array of types and it does not respond to `.to_sym`
https://github.com/patvice/ruby_llm-mcp/issues/62#issuecomment-3421488406
Fix #62 

## Summary
This PR updates the `RubyLLM::MCP::Parameter` class to use string types instead of symbol types for consistency with the MCP protocol specification.

## Changes
- **`lib/ruby_llm/mcp/parameter.rb`**
  - Removed `.to_sym` conversion in `initialize` method when calling `super`
  - Removed `.to_sym` conversion in `item_type` method, now returns string directly
  
- **`spec/ruby_llm/mcp/parameter_spec.rb`**
  - Updated test expectations to expect string types (e.g., `"string"`, `"array"`) instead of symbols (e.g., `:string`, `:array`)

## Motivation
The MCP (Model Context Protocol) specification uses string types in its JSON schema definitions. Converting types to symbols internally created an unnecessary conversion step and could lead to confusion when serializing/deserializing MCP messages. By keeping types as strings throughout, we maintain consistency with the protocol specification and simplify the codebase.

## Testing
All existing tests have been updated and pass with the new string-based type system.
