### PR TITLE
Added id in request to the notification/initialize MCP call

### DIFF
--- a/lib/ruby_llm/mcp/notifications/initialize.rb
+++ b/lib/ruby_llm/mcp/notifications/initialize.rb
@@ -9,7 +9,7 @@ module RubyLLM
         end
 
         def call
-          @coordinator.request(notification_body, add_id: false, wait_for_response: false)
+          @coordinator.request(notification_body, add_id: true, wait_for_response: false)
         end
 
         def notification_body


### PR DESCRIPTION
Closes https://github.com/patvice/ruby_llm-mcp/issues/65

The aim for this is to include an ID field on all `notification/initialize` to increase compatibility to other MCP servers