### PR TITLE
Fix missing type field handling and add title support for parameters

### DIFF
--- a/lib/ruby_llm/mcp/parameter.rb
+++ b/lib/ruby_llm/mcp/parameter.rb
@@ -5,10 +5,11 @@ require "ruby_llm/tool"
 module RubyLLM
   module MCP
     class Parameter < RubyLLM::Parameter
-      attr_accessor :items, :properties, :enum, :union_type, :default
+      attr_accessor :items, :properties, :enum, :union_type, :default, :title
 
-      def initialize(name, type: "string", desc: nil, required: true, default: nil, union_type: nil) # rubocop:disable Metrics/ParameterLists
+      def initialize(name, type: "string", title: nil, desc: nil, required: true, default: nil, union_type: nil) # rubocop:disable Metrics/ParameterLists
         super(name, type: type.to_sym, desc: desc, required: required)
+        @title = title
         @properties = {}
         @union_type = union_type
         @default = default

--- a/lib/ruby_llm/mcp/providers/anthropic/complex_parameter_support.rb
+++ b/lib/ruby_llm/mcp/providers/anthropic/complex_parameter_support.rb
@@ -17,18 +17,20 @@ module RubyLLM
             parameters.select { |_, param| param.required }.keys
           end
 
-          def build_properties(param)
+          def build_properties(param) # rubocop:disable Metrics/MethodLength
             case param.type
             when :array
               if param.item_type == :object
                 {
                   type: param.type,
+                  title: param.title,
                   description: param.description,
                   items: { type: param.item_type, properties: clean_parameters(param.properties) }
                 }.compact
               else
                 {
                   type: param.type,
+                  title: param.title,
                   description: param.description,
                   default: param.default,
                   items: { type: param.item_type, enum: param.enum }.compact
@@ -37,6 +39,7 @@ module RubyLLM
             when :object
               {
                 type: param.type,
+                title: param.title,
                 description: param.description,
                 properties: clean_parameters(param.properties),
                 required: required_parameters(param.properties)
@@ -48,6 +51,7 @@ module RubyLLM
             else
               {
                 type: param.type,
+                title: param.title,
                 description: param.description
               }.compact
             end

--- a/lib/ruby_llm/mcp/providers/gemini/complex_parameter_support.rb
+++ b/lib/ruby_llm/mcp/providers/gemini/complex_parameter_support.rb
@@ -22,6 +22,7 @@ module RubyLLM
                            if param.item_type == :object
                              {
                                type: param_type_for_gemini(param.type),
+                               title: param.title,
                                description: param.description,
                                items: {
                                  type: param_type_for_gemini(param.item_type),
@@ -31,6 +32,7 @@ module RubyLLM
                            else
                              {
                                type: param_type_for_gemini(param.type),
+                               title: param.title,
                                description: param.description,
                                default: param.default,
                                items: { type: param_type_for_gemini(param.item_type), enum: param.enum }.compact
@@ -39,6 +41,7 @@ module RubyLLM
                          when :object
                            {
                              type: param_type_for_gemini(param.type),
+                             title: param.title,
                              description: param.description,
                              properties: param.properties.transform_values { |value| build_properties(value) },
                              required: param.properties.select { |_, p| p.required }.keys
@@ -50,6 +53,7 @@ module RubyLLM
                          else
                            {
                              type: param_type_for_gemini(param.type),
+                             title: param.title,
                              description: param.description
                            }
                          end

--- a/lib/ruby_llm/mcp/providers/openai/complex_parameter_support.rb
+++ b/lib/ruby_llm/mcp/providers/openai/complex_parameter_support.rb
@@ -13,6 +13,7 @@ module RubyLLM
                            if param.item_type == :object
                              {
                                type: param.type,
+                               title: param.title,
                                description: param.description,
                                items: {
                                  type: param.item_type,
@@ -22,6 +23,7 @@ module RubyLLM
                            else
                              {
                                type: param.type,
+                               title: param.title,
                                description: param.description,
                                default: param.default,
                                items: { type: param.item_type, enum: param.enum }.compact
@@ -30,6 +32,7 @@ module RubyLLM
                          when :object
                            {
                              type: param.type,
+                             title: param.title,
                              description: param.description,
                              properties: param.properties.transform_values { |value| param_schema(value) },
                              required: param.properties.select { |_, p| p.required }.keys
@@ -41,6 +44,7 @@ module RubyLLM
                          else
                            {
                              type: param.type,
+                             title: param.title,
                              description: param.description
                            }.compact
                          end

--- a/lib/ruby_llm/mcp/tool.rb
+++ b/lib/ruby_llm/mcp/tool.rb
@@ -25,7 +25,7 @@ module RubyLLM
     end
 
     class Tool < RubyLLM::Tool
-      attr_reader :name, :description, :parameters, :coordinator, :tool_response, :with_prefix
+      attr_reader :name, :title, :description, :parameters, :coordinator, :tool_response, :with_prefix
 
       def initialize(coordinator, tool_response, with_prefix: false)
         super()
@@ -117,6 +117,7 @@ module RubyLLM
         param = RubyLLM::MCP::Parameter.new(
           key,
           type: :union,
+          title: param_data["title"],
           desc: param_data["description"],
           union_type: union_type
         )
@@ -136,7 +137,8 @@ module RubyLLM
       def process_parameter(key, param_data, lifted_type: nil)
         param = RubyLLM::MCP::Parameter.new(
           key,
-          type: param_data["type"] || lifted_type,
+          type: param_data["type"] || lifted_type || "string",
+          title: param_data["title"],
           desc: param_data["description"],
           required: param_data["required"],
           default: param_data["default"]

--- a/spec/ruby_llm/mcp/parameter_spec.rb
+++ b/spec/ruby_llm/mcp/parameter_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe RubyLLM::MCP::Parameter do
       expect(parameter.type).to eq(:string)
       expect(parameter.required).to be(true)
       expect(parameter.items).to be_nil
+      expect(parameter.title).to be_nil
     end
 
     it "creates a parameter with custom values" do
@@ -46,6 +47,18 @@ RSpec.describe RubyLLM::MCP::Parameter do
       expect(parameter.type).to eq(:array)
       expect(parameter.description).to eq("Test description")
       expect(parameter.required).to be(false)
+    end
+
+    it "creates a parameter with title" do
+      parameter = described_class.new("test_param", type: "string", title: "Test Parameter Title")
+      expect(parameter.name).to eq("test_param")
+      expect(parameter.title).to eq("Test Parameter Title")
+      expect(parameter.type).to eq(:string)
+    end
+
+    it "handles nil title gracefully" do
+      parameter = described_class.new("test_param", type: "string", title: nil)
+      expect(parameter.title).to be_nil
     end
 
     it "handles shorthand anyOf with array of types" do


### PR DESCRIPTION
# Fix Missing Type Field Handling and Add Title Support for Parameters

## Problem

This PR addresses two related issues with MCP tool parameter handling:

1. **Missing Type Field Bug**: When an MCP server returns a parameter schema without a `type` field, the code would attempt to call `.to_sym` on `nil`, raising a `NoMethodError`. This was discovered when integrating with a Google Workspace MCP server.

2. **Missing Title Field Support**: The JSON Schema `title` field on parameters was not being preserved when processing tool schemas, resulting in loss of useful metadata that providers may want to include in their parameter descriptions.

## Solution

### Type Field Handling
- Updated `Tool#process_parameter` to default to `"string"` when `type` field is `nil` or missing
- Changed from `param_data["type"] || lifted_type` to `param_data["type"] || lifted_type || "string"`

### Title Field Support  
- Added `title` as an attribute to `RubyLLM::MCP::Parameter`
- Updated parameter initialization to accept and store `title`
- Updated all provider serializers to include `title` field:
  - `Anthropic::ComplexParameterSupport#build_properties`
  - `OpenAI::ComplexParameterSupport#param_schema`
  - `Gemini::ComplexParameterSupport#build_properties`
- Updated `Tool#process_parameter` and `Tool#process_union_parameter` to pass `title` when creating parameters
