### PR TITLE
Fix intermittent CI failures due to missing Bun dependencies

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,6 +30,12 @@ jobs:
         run: |
           bundle install
 
+      - name: Install Bun dependencies for test fixtures
+        run: |
+          cd spec/fixtures/typescript-mcp && bun install
+          cd ../../..
+          cd spec/fixtures/pagination-server && bun install
+
       - name: Run specs
         run: bundle exec rake
         env:


### PR DESCRIPTION
This PR fixes intermittent test failures where sometimes the suite would error with:

```
ENOENT: no such file or directory, open '@modelcontextprotocol/sdk/server/mcp.js'
```

## Root Cause

The issue occurred because the GitHub Actions workflow never installed npm/Bun dependencies for the TypeScript test fixture servers (typescript-mcp and pagination-server).
As a result, module resolution failed when spawning those test servers.

The failures were intermittent because the GitHub Actions runner cache would sometimes preserve node_modules from previous runs, masking the problem.

## Fix

This PR adds explicit steps to run bun install in both fixture directories before executing the test suite.
This ensures dependencies are always available, regardless of the runner’s cached state.