### PR TITLE
Fixed Gem Release Warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development do
   gem "debug"
   gem "dotenv", ">= 3.0"
   gem "rake", ">= 13.0"
-  gem "rdoc"
+  gem "rdoc", "~> 6.15"
   gem "reline"
   gem "rspec", "~> 3.12"
   gem "rubocop", ">= 1.76"

--- a/ruby_llm-mcp.gemspec
+++ b/ruby_llm-mcp.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/patvice/ruby_llm-mcp"
   spec.metadata["changelog_uri"] = "#{spec.metadata['source_code_uri']}/commits/main"
-  spec.metadata["documentation_uri"] = spec.homepage
+  spec.metadata["documentation_uri"] = "#{spec.homepage}/guides/"
   spec.metadata["bug_tracker_uri"] = "#{spec.metadata['source_code_uri']}/issues"
 
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
## Fix gem build warnings

### Changes
- **Pin rdoc version**: Updated `Gemfile` to specify `rdoc ~> 6.15` to prevent version conflicts
- **Fix duplicate URI warning**: Set `documentation_uri` to point to `/guides/` instead of duplicating the homepage URL

### Impact
Eliminates all warnings during `gem build`:
- ✅ Removes ~30 RDoc constant redefinition warnings caused by multiple rdoc versions loading
- ✅ Removes rubygems.org duplicate URI warning

Build output is now clean with no warnings.