### PR TITLE
refactor: Remove reflection anti-patterns from OAuth implementation

### DIFF
--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -165,7 +165,7 @@ client = RubyLLM::MCP.client(
 )
 
 # Authenticate via browser
-transport = client.instance_variable_get(:@coordinator).send(:transport)
+transport = client.coordinator.transport
 oauth_provider = transport.oauth_provider
 
 browser_oauth = RubyLLM::MCP::Auth::BrowserOAuth.new(
@@ -200,7 +200,7 @@ client = RubyLLM::MCP.client(
 )
 
 # Authenticate
-transport = client.instance_variable_get(:@coordinator).send(:transport)
+transport = client.coordinator.transport
 browser_oauth = RubyLLM::MCP::Auth::BrowserOAuth.new(
   transport.oauth_provider,
   callback_port: 9000
@@ -227,7 +227,7 @@ client = RubyLLM::MCP.client(
   }
 )
 
-transport = client.instance_variable_get(:@coordinator).send(:transport)
+transport = client.coordinator.transport
 oauth_provider = transport.oauth_provider
 
 # Get authorization URL

--- a/lib/ruby_llm/mcp/client.rb
+++ b/lib/ruby_llm/mcp/client.rb
@@ -7,7 +7,7 @@ module RubyLLM
     class Client
       extend Forwardable
 
-      attr_reader :name, :config, :transport_type, :request_timeout, :log_level, :on, :roots
+      attr_reader :name, :config, :transport_type, :request_timeout, :log_level, :on, :roots, :coordinator
       attr_accessor :linked_resources
 
       def initialize(name:, transport_type:, start: true, request_timeout: MCP.config.request_timeout, config: {})

--- a/spec/ruby_llm/mcp/client_spec.rb
+++ b/spec/ruby_llm/mcp/client_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe RubyLLM::MCP::Client do
 
       tool = client.tool("timeout_tool")
 
-      allow(client.instance_variable_get(:@coordinator)).to receive(:cancelled_notification).and_call_original
+      allow(client.coordinator).to receive(:cancelled_notification).and_call_original
       expect { tool.execute(seconds: 2) }.to raise_error(RubyLLM::MCP::Errors::TimeoutError)
-      expect(client.instance_variable_get(:@coordinator)).to have_received(:cancelled_notification)
+      expect(client.coordinator).to have_received(:cancelled_notification)
 
       client.stop
     end
@@ -273,12 +273,12 @@ RSpec.describe RubyLLM::MCP::Client do
           cache_before_reset = client.instance_variable_get(:@resource_templates)
           expect(cache_before_reset).not_to be_empty
 
-          allow(client.instance_variable_get(:@coordinator)).to receive(:resource_template_list).and_call_original
+          allow(client.coordinator).to receive(:resource_template_list).and_call_original
           client.reset_resource_templates!
           expect(client.instance_variable_get(:@resource_templates)).to eq({})
 
           client.resource_templates
-          expect(client.instance_variable_get(:@coordinator)).to have_received(:resource_template_list)
+          expect(client.coordinator).to have_received(:resource_template_list)
         end
       end
 

--- a/spec/ruby_llm/mcp/transports/streamable_http_spec.rb
+++ b/spec/ruby_llm/mcp/transports/streamable_http_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe RubyLLM::MCP::Transports::StreamableHTTP do
     it "can access protocol version through private coordinator for verification" do
       client.start
 
-      # Access coordinator through private instance variable for testing purposes
-      coordinator = client.instance_variable_get(:@coordinator)
+      # Access coordinator through public accessor
+      coordinator = client.coordinator
       expect(coordinator.protocol_version).to be_a(String)
       expect(coordinator.protocol_version).to match(/\d{4}-\d{2}-\d{2}/)
       expect(coordinator.protocol_version).to eq("2025-03-26")
@@ -112,7 +112,7 @@ RSpec.describe RubyLLM::MCP::Transports::StreamableHTTP do
       client.start
 
       # Verify the transport has the set_protocol_version method
-      coordinator = client.instance_variable_get(:@coordinator)
+      coordinator = client.coordinator
       transport = coordinator.transport
       expect(transport).to respond_to(:set_protocol_version)
 
@@ -123,7 +123,7 @@ RSpec.describe RubyLLM::MCP::Transports::StreamableHTTP do
       client.start
 
       # Access transport through coordinator for verification
-      coordinator = client.instance_variable_get(:@coordinator)
+      coordinator = client.coordinator
       transport = coordinator.transport
 
       # The transport should have a protocol version set


### PR DESCRIPTION
@patvice Just cleaning up my mess here.

---

## Summary
- Replace `instance_variable_get(:@coordinator)` with public `coordinator` accessor
- Update OAuth documentation examples to use proper public API methods
- Fix test files to use public methods instead of reflection

## Changes Made

### 1. Added public `coordinator` accessor to Client class
- Made `@coordinator` accessible via public attr_reader in `lib/ruby_llm/mcp/client.rb`

### 2. Updated documentation
- Fixed 3 OAuth examples in `docs/guides/oauth.md` that used anti-patterns
- Changed from: `client.instance_variable_get(:@coordinator).send(:transport)`
- Changed to: `client.coordinator.transport`

### 3. Fixed test files
- Updated `spec/ruby_llm/mcp/client_spec.rb` (2 locations)
- Updated `spec/ruby_llm/mcp/transports/streamable_http_spec.rb` (3 locations)
- Replaced reflection methods with public accessors

## Why This Matters
- **Better Encapsulation**: Public methods provide a proper API contract
- **Maintainability**: Code won't break if internal implementation changes
- **Best Practices**: Follows Ruby conventions and OOP principles
- **Documentation Quality**: Examples now demonstrate proper usage patterns

## Test plan
- [x] Verify coordinator is accessible as public method
- [x] Confirm OAuth provider access works through clean method chain
- [x] Check all documentation examples use public methods
- [x] Ensure no functionality was broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)