### PR TITLE
Fix Zeitwerk eager loading crash in non-Rails environments

### DIFF
--- a/lib/ruby_llm/mcp.rb
+++ b/lib/ruby_llm/mcp.rb
@@ -100,9 +100,10 @@ module RubyLLM
   end
 end
 
-require_relative "mcp/railtie" if defined?(Rails::Railtie)
-
 loader = Zeitwerk::Loader.for_gem_extension(RubyLLM)
+
+loader.ignore("#{__dir__}/mcp/railtie.rb")
+
 loader.inflector.inflect("mcp" => "MCP")
 loader.inflector.inflect("sse" => "SSE")
 loader.inflector.inflect("openai" => "OpenAI")
@@ -118,3 +119,7 @@ loader.inflector.inflect("oauth_provider" => "OAuthProvider")
 loader.inflector.inflect("browser_oauth_provider" => "BrowserOAuthProvider")
 
 loader.setup
+
+if defined?(Rails::Railtie)
+  require_relative "mcp/railtie"
+end

--- a/lib/ruby_llm/mcp/railtie.rb
+++ b/lib/ruby_llm/mcp/railtie.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-module RubyLLM
-  module MCP
-    class Railtie < Rails::Railtie
-      generators do
-        require_relative "../../generators/ruby_llm/mcp/install/install_generator"
-        require_relative "../../generators/ruby_llm/mcp/oauth/install_generator"
+if defined?(Rails::Railtie)
+  module RubyLLM
+    module MCP
+      class Railtie < Rails::Railtie
+        generators do
+          require_relative "../../generators/ruby_llm/mcp/install/install_generator"
+          require_relative "../../generators/ruby_llm/mcp/oauth/install_generator"
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- Fixes NameError crashes during Zeitwerk eager loading when `railtie.rb` is loaded in non-Rails environments
- Wraps Railtie class definition with conditional check
- Adds Zeitwerk ignore directive for `railtie.rb`

## Problem

Applications crash during Zeitwerk eager loading when `railtie.rb` references `Rails::Railtie` in non-Rails contexts. The error occurs because Zeitwerk's eager loading happens before conditional require checks can run.

## Solution

This PR implements two complementary fixes (both are required):

1. **Wrap class definition conditionally** in `railtie.rb`:
   - Ensures the Railtie class is only defined when `Rails::Railtie` is available
   
2. **Ignore from Zeitwerk** in `mcp.rb`:
   - Tells Zeitwerk to skip loading `railtie.rb` during eager loading
   - The file is still loaded conditionally after `loader.setup`

## Testing

Verified that `railtie.rb` loads successfully without Rails present:
```bash
bundle exec ruby -e "load 'lib/ruby_llm/mcp/railtie.rb'"
# SUCCESS: No NameError
```

## Related

Similar fix applied to upstream ruby_llm in [crmne/ruby_llm#486](https://github.com/crmne/ruby_llm/pull/486)

🤖 Generated with [Claude Code](https://claude.com/claude-code)