### PR TITLE
Add Zeitwerk eager loading check to CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,6 +30,9 @@ jobs:
         run: |
           bundle install
 
+      - name: Check Zeitwerk eager loading
+        run: bundle exec ruby -e "require 'ruby_llm/mcp'; Zeitwerk::Loader.eager_load_all"
+
       - name: Install Bun dependencies for test fixtures
         run: |
           cd spec/fixtures/typescript-mcp && bun install


### PR DESCRIPTION
## Summary

- Adds `Zeitwerk::Loader.eager_load_all` validation to the CI test job
- Runs after Ruby dependencies are installed and before Bun fixtures/specs
- Rebased onto current `patvice/main` after `ruby_llm-mcp` PR #94 was merged

## Problem

Without automated Zeitwerk eager loading validation, autoloading issues can slip into production causing crashes. These issues include:

- Inflector configuration errors
- Constant definition problems
- Missing conditional checks for optional dependencies

## Solution

Add a simple validation step that runs `Zeitwerk::Loader.eager_load_all` after dependency installation. This structural validation provides fast feedback before the rest of the test job continues.

## Upstream Status

The original blocker in RubyLLM has been fixed on `ruby_llm` main:

- [ruby_llm#504](https://github.com/crmne/ruby_llm/pull/504) merged on May 6, 2026 and fixes the ActiveRecord dependency/eager-loading failure.
- [ruby_llm#505](https://github.com/crmne/ruby_llm/pull/505) was closed unmerged on March 1, 2026, so this PR no longer treats it as a blocker.

This PR remains draft until a published `ruby_llm` gem release includes #504. The current latest RubyGems release is `ruby_llm` 1.14.1 from April 2, 2026, which still predates the fix.

## Testing

Local verification after rebasing still fails with the expected upstream gem issue because Bundler resolves `ruby_llm` 1.14.1:

```text
uninitialized constant RubyLLM::ActiveRecord::ActsAs::ActiveSupport (NameError)
```

Command run locally:

```sh
RBENV_VERSION=3.4.9 rbenv exec bundle exec ruby -e "require 'ruby_llm/mcp'; Zeitwerk::Loader.eager_load_all"
```
