### PR TITLE
Full Cancelation Notification Support

### DIFF
--- a/lib/ruby_llm/mcp/adapters/ruby_llm_adapter.rb
+++ b/lib/ruby_llm/mcp/adapters/ruby_llm_adapter.rb
@@ -63,7 +63,9 @@ module RubyLLM
                        :roots_list_change_notification,
                        :ping_response, :roots_list_response,
                        :sampling_create_message_response,
-                       :error_response, :elicitation_response
+                       :error_response, :elicitation_response,
+                       :register_in_flight_request, :unregister_in_flight_request,
+                       :cancel_in_flight_request
 
         # Handle resource registration in adapter (public API concern)
         def register_resource(resource)

--- a/lib/ruby_llm/mcp/client.rb
+++ b/lib/ruby_llm/mcp/client.rb
@@ -52,7 +52,9 @@ module RubyLLM
         @adapter.start if start
       end
 
-      def_delegators :@adapter, :alive?, :capabilities, :ping, :client_capabilities
+      def_delegators :@adapter, :alive?, :capabilities, :ping, :client_capabilities,
+                     :register_in_flight_request, :unregister_in_flight_request,
+                     :cancel_in_flight_request
 
       def start
         @adapter.start

--- a/lib/ruby_llm/mcp/elicitation.rb
+++ b/lib/ruby_llm/mcp/elicitation.rb
@@ -20,6 +20,7 @@ module RubyLLM
 
       def execute
         success = @coordinator.elicitation_callback&.call(self)
+
         if success
           valid = validate_response
           if valid

--- a/lib/ruby_llm/mcp/errors.rb
+++ b/lib/ruby_llm/mcp/errors.rb
@@ -77,6 +77,15 @@ module RubyLLM
       class UnsupportedTransport < BaseError; end
 
       class AdapterConfigurationError < BaseError; end
+
+      class RequestCancelled < BaseError
+        attr_reader :request_id
+
+        def initialize(message:, request_id:)
+          @request_id = request_id
+          super(message: message)
+        end
+      end
     end
   end
 end

--- a/lib/ruby_llm/mcp/native/cancellable_operation.rb
+++ b/lib/ruby_llm/mcp/native/cancellable_operation.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module RubyLLM
+  module MCP
+    module Native
+      # Wraps server-initiated requests to support cancellation
+      # Executes the request in a separate thread that can be terminated on cancellation
+      class CancellableOperation
+        attr_reader :request_id, :thread
+
+        def initialize(request_id)
+          @request_id = request_id
+          @cancelled = false
+          @mutex = Mutex.new
+          @thread = nil
+          @result = nil
+          @error = nil
+        end
+
+        def cancelled?
+          @mutex.synchronize { @cancelled }
+        end
+
+        def cancel
+          @mutex.synchronize { @cancelled = true }
+          if @thread&.alive?
+            @thread.raise(Errors::RequestCancelled.new(
+                            message: "Request #{@request_id} was cancelled",
+                            request_id: @request_id
+                          ))
+          end
+        end
+
+        # Execute a block in a separate thread
+        # This allows the thread to be terminated if cancellation is requested
+        # Returns the result of the block or re-raises any error that occurred
+        def execute(&)
+          @thread = Thread.new do
+            Thread.current.abort_on_exception = false
+            begin
+              @result = yield
+            rescue Errors::RequestCancelled, StandardError => e
+              @error = e
+            end
+          end
+
+          @thread.join
+          raise @error if @error && !@error.is_a?(Errors::RequestCancelled)
+
+          @result
+        ensure
+          @thread = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/ruby_llm/mcp/native/client.rb
+++ b/lib/ruby_llm/mcp/native/client.rb
@@ -44,6 +44,10 @@ module RubyLLM
 
           @transport = nil
           @capabilities = nil
+
+          # Track in-flight server-initiated requests for cancellation
+          @in_flight_requests = {}
+          @in_flight_mutex = Mutex.new
         end
 
         def request(body, **options)
@@ -315,6 +319,41 @@ module RubyLLM
 
         def transport
           @transport ||= Native::Transport.new(@transport_type, self, config: @config)
+        end
+
+        # Register a server-initiated request that can be cancelled
+        # @param request_id [String] The ID of the request
+        # @param cancellable_operation [CancellableOperation, nil] The operation that can be cancelled
+        def register_in_flight_request(request_id, cancellable_operation = nil)
+          @in_flight_mutex.synchronize do
+            @in_flight_requests[request_id.to_s] = cancellable_operation
+          end
+        end
+
+        # Unregister a completed or cancelled request
+        # @param request_id [String] The ID of the request
+        def unregister_in_flight_request(request_id)
+          @in_flight_mutex.synchronize do
+            @in_flight_requests.delete(request_id.to_s)
+          end
+        end
+
+        # Cancel an in-flight server-initiated request
+        # @param request_id [String] The ID of the request to cancel
+        # @return [Boolean] true if the request was found and cancelled, false otherwise
+        def cancel_in_flight_request(request_id) # rubocop:disable Naming/PredicateMethod
+          operation = nil
+          @in_flight_mutex.synchronize do
+            operation = @in_flight_requests[request_id.to_s]
+          end
+
+          if operation.respond_to?(:cancel)
+            operation.cancel
+            true
+          else
+            RubyLLM::MCP.logger.warn("Request #{request_id} cannot be cancelled or was already completed")
+            false
+          end
         end
       end
     end

--- a/spec/fixtures/vcr_cassettes/Cancellation_Integration/with_stdio-native/End-to-end_cancellation_with_stdio-native/allows_multiple_cancellations_without_errors.yml
+++ b/spec/fixtures/vcr_cassettes/Cancellation_Integration/with_stdio-native/End-to-end_cancellation_with_stdio-native/allows_multiple_cancellations_without_errors.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"developer","content":"You are
+        a helpful assistant."},{"role":"user","content":"Hello, how are you?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Authorization:
+      - Bearer test
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 24 Nov 2025 18:09:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '254'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      X-Envoy-Upstream-Service-Time:
+      - '0'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |
+        {
+            "error": {
+                "message": "Incorrect API key provided: test. You can find your API key at https://platform.openai.com/account/api-keys.",
+                "type": "invalid_request_error",
+                "param": null,
+                "code": "invalid_api_key"
+            }
+        }
+  recorded_at: Mon, 24 Nov 2025 18:09:15 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Cancellation_Integration/with_stdio-native/End-to-end_cancellation_with_stdio-native/handles_server-initiated_cancellation_of_sampling_requests.yml
+++ b/spec/fixtures/vcr_cassettes/Cancellation_Integration/with_stdio-native/End-to-end_cancellation_with_stdio-native/handles_server-initiated_cancellation_of_sampling_requests.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"developer","content":"You are
+        a helpful assistant."},{"role":"user","content":"This is a long message that
+        should be cancelled"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Authorization:
+      - Bearer test
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 24 Nov 2025 18:14:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '254'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      X-Envoy-Upstream-Service-Time:
+      - '1'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |
+        {
+            "error": {
+                "message": "Incorrect API key provided: test. You can find your API key at https://platform.openai.com/account/api-keys.",
+                "type": "invalid_request_error",
+                "param": null,
+                "code": "invalid_api_key"
+            }
+        }
+  recorded_at: Mon, 24 Nov 2025 18:14:12 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Cancellation_Integration/with_stdio-native/End-to-end_cancellation_with_stdio-native/properly_cleans_up_cancelled_requests.yml
+++ b/spec/fixtures/vcr_cassettes/Cancellation_Integration/with_stdio-native/End-to-end_cancellation_with_stdio-native/properly_cleans_up_cancelled_requests.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"developer","content":"You are
+        a helpful assistant."},{"role":"user","content":"This is a long message that
+        should be cancelled"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Authorization:
+      - Bearer test
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 24 Nov 2025 18:14:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '254'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      X-Envoy-Upstream-Service-Time:
+      - '0'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |
+        {
+            "error": {
+                "message": "Incorrect API key provided: test. You can find your API key at https://platform.openai.com/account/api-keys.",
+                "type": "invalid_request_error",
+                "param": null,
+                "code": "invalid_api_key"
+            }
+        }
+  recorded_at: Mon, 24 Nov 2025 18:14:12 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/Cancellation_Integration/with_streamable-native/End-to-end_cancellation_with_streamable-native/properly_cleans_up_cancelled_requests.yml
+++ b/spec/fixtures/vcr_cassettes/Cancellation_Integration/with_streamable-native/End-to-end_cancellation_with_streamable-native/properly_cleans_up_cancelled_requests.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"developer","content":"You are
+        a helpful assistant."},{"role":"user","content":"This request should be cancelled
+        by the client"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Authorization:
+      - Bearer test
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 24 Nov 2025 18:15:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '254'
+      Connection:
+      - keep-alive
+      Vary:
+      - Origin
+      X-Request-Id:
+      - "<X_REQUEST_ID>"
+      X-Envoy-Upstream-Service-Time:
+      - '0'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>"
+      - "<COOKIE>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |
+        {
+            "error": {
+                "message": "Incorrect API key provided: test. You can find your API key at https://platform.openai.com/account/api-keys.",
+                "type": "invalid_request_error",
+                "param": null,
+                "code": "invalid_api_key"
+            }
+        }
+  recorded_at: Mon, 24 Nov 2025 18:15:31 GMT
+recorded_with: VCR 6.3.1

--- a/spec/ruby_llm/mcp/cancellation_integration_spec.rb
+++ b/spec/ruby_llm/mcp/cancellation_integration_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Cancellation Integration", :vcr do # rubocop:disable RSpec/DescribeClass
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    ClientRunner.build_client_runners(CLIENT_OPTIONS)
+  end
+
+  before do
+    MCPTestConfiguration.reset_config!
+    MCPTestConfiguration.configure_ruby_llm!
+  end
+
+  around do |example|
+    cassette_name = example.full_description
+                           .delete_prefix("RubyLLM::MCP::")
+                           .downcase
+                           .gsub(", ", "")
+                           .gsub(" ", "_")
+                           .gsub("/", "_")
+
+    VCR.use_cassette(cassette_name, allow_playback_repeats: true) do
+      example.run
+    end
+  end
+
+  each_client_supporting(:sampling) do |config|
+    describe "End-to-end cancellation with #{config[:name]}" do
+      let(:client) { RubyLLM::MCP::Client.new(**config[:options], start: false) }
+
+      after do
+        client.stop if client.alive?
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it "handles server-initiated cancellation of sampling requests" do
+        # Enable sampling so the client can handle sampling requests
+        RubyLLM::MCP.configure do |config|
+          config.sampling.enabled = true
+          config.sampling.preferred_model = "gpt-4o"
+        end
+
+        # Track if sampling was actually cancelled (shouldn't complete)
+        sampling_completed = false
+        sampling_request_id = nil
+
+        # Set up a sampling callback that would take time if not cancelled
+        client.on_sampling do |sample|
+          sampling_request_id = sample.to_h[:id]
+          # This should be interrupted by cancellation
+          sleep 1.0
+          sampling_completed = true
+          true
+        end
+
+        client.start
+
+        # Call the tool in a thread so we can cancel it
+        tool_thread = Thread.new do
+          tool = client.tool("sample_with_cancellation")
+          tool.execute
+        end
+
+        # Wait for the sampling request to start
+        sleep 0.1 until sampling_request_id
+
+        # Send cancellation notification for the sampling request
+        notification = RubyLLM::MCP::Notification.new(
+          {
+            "method" => "notifications/cancelled",
+            "params" => {
+              "requestId" => sampling_request_id,
+              "reason" => "Test cancellation"
+            }
+          }
+        )
+
+        notification_handler = RubyLLM::MCP::NotificationHandler.new(client)
+        notification_handler.execute(notification)
+
+        # Wait a bit for cancellation to take effect
+        sleep 0.2
+
+        # Verify our sampling callback never completed
+        expect(sampling_completed).to be false
+
+        # Clean up
+        tool_thread.kill if tool_thread.alive?
+        tool_thread.join
+      end
+      # rubocop:enable RSpec/ExampleLength
+
+      # rubocop:disable RSpec/ExampleLength
+      it "properly cleans up cancelled requests" do
+        # Enable sampling
+        RubyLLM::MCP.configure do |config|
+          config.sampling.enabled = true
+          config.sampling.preferred_model = "gpt-4o"
+        end
+
+        request_ids = []
+
+        client.on_sampling do |sample|
+          request_ids << sample.to_h[:id]
+          sleep 0.5
+          true
+        end
+
+        client.start
+
+        # Start multiple sampling requests
+        threads = 3.times.map do
+          Thread.new do
+            tool = client.tool("sample_with_cancellation")
+            tool.execute
+          end
+        end
+
+        # Wait for ALL requests to start
+        sleep 0.1 until request_ids.length >= 3
+
+        # Cancel each request as soon as we detect it
+        cancelled_ids = []
+        request_ids.each do |request_id|
+          notification = RubyLLM::MCP::Notification.new(
+            {
+              "method" => "notifications/cancelled",
+              "params" => {
+                "requestId" => request_id,
+                "reason" => "Test cancellation"
+              }
+            }
+          )
+
+          notification_handler = RubyLLM::MCP::NotificationHandler.new(client)
+          notification_handler.execute(notification)
+          cancelled_ids << request_id
+        end
+
+        # Wait for cancellations to propagate
+        sleep 0.3
+
+        # Clean up threads
+        threads.each do |t|
+          t.kill if t.alive?
+          t.join
+        end
+
+        # Verify all cancelled requests are cleaned up
+        in_flight = client.adapter.native_client.instance_variable_get(:@in_flight_requests)
+        cancelled_ids.each do |id|
+          expect(in_flight.key?(id.to_s)).to be false
+        end
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+  end
+end

--- a/spec/ruby_llm/mcp/native/cancellable_operation_spec.rb
+++ b/spec/ruby_llm/mcp/native/cancellable_operation_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyLLM::MCP::Native::CancellableOperation do
+  let(:request_id) { "test-request-123" }
+  let(:operation) { described_class.new(request_id) }
+
+  describe "#initialize" do
+    it "sets the request_id" do
+      expect(operation.request_id).to eq(request_id)
+    end
+
+    it "initializes as not cancelled" do
+      expect(operation.cancelled?).to be false
+    end
+
+    it "initializes with no thread" do
+      expect(operation.thread).to be_nil
+    end
+  end
+
+  describe "#cancelled?" do
+    it "returns false by default" do
+      expect(operation.cancelled?).to be false
+    end
+
+    it "returns true after cancel is called" do
+      operation.cancel
+      expect(operation.cancelled?).to be true
+    end
+  end
+
+  describe "#execute" do
+    it "executes the block in a separate thread" do
+      execution_thread = nil
+      calling_thread = Thread.current
+
+      operation.execute do
+        execution_thread = Thread.current
+      end
+
+      expect(execution_thread).not_to be_nil
+      expect(execution_thread).not_to eq(calling_thread)
+    end
+
+    it "clears the thread reference after execution" do
+      operation.execute { "test" }
+      expect(operation.thread).to be_nil
+    end
+
+    it "returns the result of the block" do
+      result = operation.execute { "test result" }
+      expect(result).to eq("test result")
+    end
+
+    it "re-raises StandardError exceptions" do
+      expect do
+        operation.execute { raise StandardError, "test error" }
+      end.to raise_error(StandardError, "test error")
+
+      expect(operation.thread).to be_nil
+    end
+
+    it "does not re-raise RequestCancelled exceptions" do
+      operation.cancel
+
+      # Give the operation a chance to start before cancelling
+      expect do
+        operation.execute { sleep 0.1 }
+      end.not_to raise_error
+
+      expect(operation.thread).to be_nil
+    end
+  end
+
+  describe "#cancel" do
+    it "sets the cancelled flag" do
+      operation.cancel
+      expect(operation.cancelled?).to be true
+    end
+
+    context "when a thread is executing" do
+      it "terminates the executing thread with RequestCancelled" do
+        started = false
+        finished = false
+
+        # Start execution in a separate thread
+        execution_thread = Thread.new do
+          operation.execute do
+            started = true
+            sleep 1 # Long operation
+            finished = true
+          end
+        end
+
+        # Wait for execution to start
+        sleep 0.01 until started
+
+        # Cancel while executing
+        operation.cancel
+
+        # Wait for the thread to complete
+        execution_thread.join
+
+        # The operation should have been cancelled before finishing
+        expect(finished).to be false
+        expect(operation.cancelled?).to be true
+      end
+    end
+
+    context "when no thread is executing" do
+      it "does not raise an error" do
+        expect { operation.cancel }.not_to raise_error
+      end
+    end
+  end
+
+  describe "thread safety" do
+    it "handles concurrent cancellation checks safely" do
+      threads = 10.times.map do
+        Thread.new { operation.cancelled? }
+      end
+
+      threads.each(&:join)
+      expect(operation.cancelled?).to be false
+    end
+
+    it "handles concurrent cancellation calls safely" do
+      threads = 10.times.map do
+        Thread.new { operation.cancel }
+      end
+
+      threads.each(&:join)
+      expect(operation.cancelled?).to be true
+    end
+  end
+end

--- a/spec/ruby_llm/mcp/native/response_handler_spec.rb
+++ b/spec/ruby_llm/mcp/native/response_handler_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe RubyLLM::MCP::Native::ResponseHandler do
 
   before do
     allow(client).to receive(:error_response).and_return(true)
+    allow(client).to receive(:register_in_flight_request)
+    allow(client).to receive(:unregister_in_flight_request)
   end
 
   it "response with an error code if the request is unknown" do
@@ -16,5 +18,41 @@ RSpec.describe RubyLLM::MCP::Native::ResponseHandler do
     request_handler.execute(result)
     error_message = "Unknown method and could not respond: #{result.method}"
     expect(client).to have_received(:error_response).with(id: "123", message: error_message, code: -32_000)
+  end
+
+  describe "cancellation handling" do
+    it "registers and unregisters in-flight requests" do
+      allow(client).to receive(:ping_response)
+      result = RubyLLM::MCP::Result.new(
+        { "id" => "456", "method" => "ping", "params" => {} }
+      )
+
+      request_handler.execute(result)
+
+      expect(client).to have_received(:register_in_flight_request).with("456", instance_of(RubyLLM::MCP::Native::CancellableOperation))
+      expect(client).to have_received(:unregister_in_flight_request).with("456")
+    end
+
+    it "does not send a response when a request is cancelled" do
+      allow(client).to receive(:roots_paths).and_return(["/path"])
+      allow(client).to receive(:roots_list_response)
+
+      result = RubyLLM::MCP::Result.new(
+        { "id" => "789", "method" => "roots/list", "params" => {} }
+      )
+
+      # Simulate cancellation by stubbing the CancellableOperation to raise RequestCancelled
+      cancelled_operation = instance_double(RubyLLM::MCP::Native::CancellableOperation)
+      allow(RubyLLM::MCP::Native::CancellableOperation).to receive(:new).with("789").and_return(cancelled_operation)
+      allow(cancelled_operation).to receive(:execute).and_raise(
+        RubyLLM::MCP::Errors::RequestCancelled.new(message: "Cancelled", request_id: "789")
+      )
+
+      result = request_handler.execute(result)
+
+      expect(result).to be true
+      expect(client).not_to have_received(:roots_list_response)
+      expect(client).to have_received(:unregister_in_flight_request).with("789")
+    end
   end
 end


### PR DESCRIPTION
## Add MCP Cancellation Notification Support

Implements support for the MCP protocol's `notifications/cancelled` message, enabling servers to cancel long-running client operations.

### Changes

- **`CancellableOperation`** - Thread-safe wrapper for cancellable operations that executes work in separate threads
- **`Notifications::Cancelled`** - Sends cancellation notifications to servers with request ID and reason
- **`NotificationHandler`** - Processes incoming `notifications/cancelled` messages and triggers cancellation
- **`Client#cancel_in_flight_request`** - Cancels in-flight operations by request ID
- **`Errors::RequestCancelled`** - New error type for signaling cancelled requests
- Integration and unit tests covering cancellation flows

Enables servers to interrupt client operations like sampling requests that are taking too long or are no longer needed.