### PR TITLE
Solved another spec race condition with that effects JRuby

### DIFF
--- a/lib/ruby_llm/mcp/handlers/async_response.rb
+++ b/lib/ruby_llm/mcp/handlers/async_response.rb
@@ -5,7 +5,7 @@ module RubyLLM
     module Handlers
       # Represents an async response for deferred completion
       class AsyncResponse
-        attr_reader :elicitation_id, :state, :result, :error
+        attr_reader :elicitation_id
 
         VALID_STATES = %i[pending completed rejected cancelled timed_out].freeze
 
@@ -95,32 +95,44 @@ module RubyLLM
 
         # Check if operation is pending
         def pending?
-          @state == :pending
+          @mutex.synchronize { @state == :pending }
         end
 
         # Check if operation is completed
         def completed?
-          @state == :completed
+          @mutex.synchronize { @state == :completed }
         end
 
         # Check if operation is rejected
         def rejected?
-          @state == :rejected
+          @mutex.synchronize { @state == :rejected }
         end
 
         # Check if operation is cancelled
         def cancelled?
-          @state == :cancelled
+          @mutex.synchronize { @state == :cancelled }
         end
 
         # Check if operation timed out
         def timed_out?
-          @state == :timed_out
+          @mutex.synchronize { @state == :timed_out }
         end
 
         # Check if operation is finished (any terminal state)
         def finished?
           !pending?
+        end
+
+        def state
+          @mutex.synchronize { @state }
+        end
+
+        def result
+          @mutex.synchronize { @result }
+        end
+
+        def error
+          @mutex.synchronize { @error }
         end
 
         private

--- a/lib/ruby_llm/mcp/native/transports/support/timeout.rb
+++ b/lib/ruby_llm/mcp/native/transports/support/timeout.rb
@@ -22,6 +22,7 @@ module RubyLLM
                 result
               else
                 worker.kill # stop the thread (can still have some risk if shared resources)
+                worker.join(0.1)
                 raise RubyLLM::MCP::Errors::TimeoutError.new(
                   message: "Request timed out after #{seconds} seconds",
                   request_id: request_id


### PR DESCRIPTION
**Problem**
JRuby CI was intermittently failing in `Cancellation Integration` (`stdio-native`) due to concurrency races in cancellation paths. The failing spec relied on unsynchronized shared state between threads, which is more likely to flake on JRuby / cause issues in production settings though MRI should be safe to do it's thread model. 

I also found a related runtime race where a cancellable operation could be marked `running` before its worker thread was safely published, causing cancellation to miss the thread in rare timing windows.

**Solution**
- Made cancellation integration specs thread-safe by replacing shared mutable variables/arrays with `Queue`-based signaling.
- Updated cancellation worker thread handling to tolerate `TransportError` during teardown races.
- Fixed `CancellableOperation` to publish `state` and `thread` atomically under mutex, so cancellation always sees a consistent state.
- Hardened concurrent state/value reads in `Promise` and `AsyncResponse` with synchronized accessors.
- Added a small timeout helper cleanup improvement (`kill` + short `join`) to reduce orphaned worker threads after timeout.
