### PR TITLE
Widen json-schema dependency to allow 5.0 through 6.2.0

### DIFF
--- a/ruby_llm-mcp.gemspec
+++ b/ruby_llm-mcp.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
 
   # Runtime dependencies
   spec.add_dependency "httpx", "~> 1.4"
-  spec.add_dependency "json-schema", "~> 5.0"
+  spec.add_dependency "json-schema", ">= 5.0", "< 7"
   spec.add_dependency "json_schemer", "~> 2.4"
   spec.add_dependency "ruby_llm", "~> 1.9"
   spec.add_dependency "zeitwerk", "~> 2"


### PR DESCRIPTION
This pull request makes a minor update to the `ruby_llm-mcp.gemspec` file, specifically adjusting the version constraint for the `json-schema` dependency to allow versions from 5.0 up to and including 6.2.0. This change increases compatibility with newer versions of the `json-schema` gem while still restricting it to a safe range.